### PR TITLE
Update livecheck blocks

### DIFF
--- a/Casks/m-dwsim.rb
+++ b/Casks/m-dwsim.rb
@@ -2,8 +2,10 @@ cask "m-dwsim" do
   version "8.7.1"
   sha256 :no_check
 
-  url "https://downloads.sourceforge.net/project/dwsim/DWSIM/DWSIM%20#{version.major_minor}/#{version}/DWSIM%20#{version}.dmg"
+  url "https://downloads.sourceforge.net/dwsim/DWSIM%20#{version}.dmg",
+      verified: "downloads.sourceforge.net/dwsim/"
   name "DWSIM"
+  desc "Chemical process simulator"
   homepage "https://dwsim.org/"
 
   livecheck do

--- a/Casks/m-dwsim.rb
+++ b/Casks/m-dwsim.rb
@@ -9,8 +9,8 @@ cask "m-dwsim" do
   homepage "https://dwsim.org/"
 
   livecheck do
-    url "https://github.com/DanWBR/dwsim/releases/"
-    strategy :github_latest
+    url "https://sourceforge.net/projects/dwsim/rss?path=/DWSIM"
+    regex(%r{url=.*?/DWSIM(?:[._-]|%20)v?(\d+(?:\.\d+)+)\.dmg}i)
   end
 
   app "DWSIM.app"

--- a/Casks/m-libreoffice.rb
+++ b/Casks/m-libreoffice.rb
@@ -10,8 +10,10 @@ cask "m-libreoffice" do
   # RC:
   # url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}.dmg"
   # Dev:
-  url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/#{folder}/LibreOfficeDev_#{version}_MacOS_#{arch}.dmg"
+  url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/#{folder}/LibreOfficeDev_#{version}_MacOS_#{arch}.dmg",
+      verified: "download.documentfoundation.org/libreoffice/"
   name "LibreOffice"
+  desc "Free cross-platform office suite"
   homepage "https://www.libreoffice.org/"
 
   livecheck do
@@ -34,6 +36,8 @@ cask "m-libreoffice" do
       page[:content].scan(regex).flatten
     end
   end
+
+  depends_on macos: ">= :big_sur"
 
   # Stable, RC:
   # app "LibreOffice.app"

--- a/Casks/m-libreoffice.rb
+++ b/Casks/m-libreoffice.rb
@@ -18,19 +18,18 @@ cask "m-libreoffice" do
 
   livecheck do
     url "https://download.documentfoundation.org/libreoffice/testing/"
-    regex(/"LibreOffice(?:Dev)[._-](.+)[._-]MacOS[._-]#{arch}\.dmg"/i)
+    regex(/href=.*?LibreOffice(?:Dev)?[._-]v?(.+?)[._-]MacOS[._-]#{arch}\.dmg/i)
     strategy :page_match do |page, regex|
-      version = page.scan(%r{href=["']v?(\d+(?:\.\d+)+)/?["' >]}i)
-                    .flatten
-                    .uniq
-                    .map { |v| Version.new(v) }
-                    .sort
-      next if version.blank?
+      versions = page.scan(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
+                     .flatten
+                     .uniq
+                     .map { |v| Version.new(v) }
+                     .sort
+      next if versions.blank?
 
-      path = version.last.to_s.concat("/mac/#{folder}/".to_s)
-      next if path.blank?
-
-      page = Homebrew::Livecheck::Strategy.page_content(URI.join(@url, path).to_s)
+      page = Homebrew::Livecheck::Strategy.page_content(
+        URI.join(@url, "#{versions.last}/mac/#{folder}/").to_s,
+      )
       next if page[:content].blank?
 
       page[:content].scan(regex).flatten

--- a/Casks/m-libreoffice.rb
+++ b/Casks/m-libreoffice.rb
@@ -6,9 +6,9 @@ cask "m-libreoffice" do
   sha256 :no_check
 
   # Stable:
-  #url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}.dmg"
+  # url "https://download.documentfoundation.org/libreoffice/stable/#{version}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}.dmg"
   # RC:
-  #url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}.dmg"
+  # url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/#{folder}/LibreOffice_#{version}_MacOS_#{arch}.dmg"
   # Dev:
   url "https://download.documentfoundation.org/libreoffice/testing/#{version.major_minor_patch}/mac/#{folder}/LibreOfficeDev_#{version}_MacOS_#{arch}.dmg"
   name "LibreOffice"
@@ -36,7 +36,7 @@ cask "m-libreoffice" do
   end
 
   # Stable, RC:
-  #app "LibreOffice.app"
+  # app "LibreOffice.app"
   # Dev:
   app "LibreOfficeDev.app", target: "LibreOffice.app"
   shimscript = "#{staged_path}/soffice.wrapper.sh"

--- a/Casks/m-little-snitch.rb
+++ b/Casks/m-little-snitch.rb
@@ -7,6 +7,7 @@ cask "m-little-snitch" do
   # Nightly:
   # url "https://sw-update.obdev.at/ftp/pub/Products/LittleSnitch/nightly/LittleSnitch-#{version.csv.first}-nightly-(#{version.csv.second}).dmg"
   name "Little Snitch"
+  desc "Host-based application firewall"
   homepage "https://www.obdev.at/products/littlesnitch/index.html"
 
   livecheck do
@@ -23,6 +24,8 @@ cask "m-little-snitch" do
       end
     end
   end
+
+  depends_on macos: ">= :sonoma"
 
   app "Little Snitch.app"
 end

--- a/Casks/m-little-snitch.rb
+++ b/Casks/m-little-snitch.rb
@@ -5,7 +5,7 @@ cask "m-little-snitch" do
   # Stable:
   url "https://sw-update.obdev.at/ftp/pub/Products/LittleSnitch/LittleSnitch-#{version}.dmg"
   # Nightly:
-  #url "https://sw-update.obdev.at/ftp/pub/Products/LittleSnitch/nightly/LittleSnitch-#{version.csv.first}-nightly-(#{version.csv.second}).dmg"
+  # url "https://sw-update.obdev.at/ftp/pub/Products/LittleSnitch/nightly/LittleSnitch-#{version.csv.first}-nightly-(#{version.csv.second}).dmg"
   name "Little Snitch"
   homepage "https://www.obdev.at/products/littlesnitch/index.html"
 

--- a/Casks/m-mactex-no-gui.rb
+++ b/Casks/m-mactex-no-gui.rb
@@ -2,8 +2,10 @@ cask "m-mactex-no-gui" do
   version "2024.0312"
   sha256 :no_check
 
-  url "http://mirror.aarnet.edu.au/pub/CTAN/systems/mac/mactex/mactex-#{version.no_dots}.pkg"
+  url "http://mirror.aarnet.edu.au/pub/CTAN/systems/mac/mactex/mactex-#{version.no_dots}.pkg",
+      verified: "mirror.aarnet.edu.au/pub/CTAN/systems/mac/mactex/"
   name "MacTeX"
+  desc "Full TeX Live distribution without GUI applications"
   homepage "https://www.tug.org/mactex/"
 
   livecheck do
@@ -11,6 +13,7 @@ cask "m-mactex-no-gui" do
   end
 
   depends_on formula: "ghostscript"
+  depends_on macos: ">= :mojave"
 
   pkg "mactex-#{version.no_dots}.pkg",
       # installer -showChoicesXML -pkg filename.pkg -target /

--- a/Casks/m-microsoft-defender.rb
+++ b/Casks/m-microsoft-defender.rb
@@ -4,6 +4,7 @@ cask "m-microsoft-defender" do
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Defender_#{version}_Individuals_Installer.pkg"
   name "Microsoft Defender"
+  desc "Security app that helps protect devices, data, and identities"
   homepage "https://www.microsoft.com/en-au/microsoft-365/microsoft-defender-for-individuals"
 
   livecheck do

--- a/Casks/m-microsoft-outlook.rb
+++ b/Casks/m-microsoft-outlook.rb
@@ -4,6 +4,7 @@ cask "m-microsoft-outlook" do
 
   url "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Outlook_#{version}_Installer.pkg"
   name "Microsoft Outlook"
+  desc "Email client"
   homepage "https://www.microsoft.com/en-us/microsoft-365/outlook/outlook-for-business"
 
   livecheck do

--- a/Casks/m-microsoft-teams.rb
+++ b/Casks/m-microsoft-teams.rb
@@ -2,8 +2,10 @@ cask "m-microsoft-teams" do
   version "24124.1412.2911.3341"
   sha256 :no_check
 
-  url "https://statics.teams.cdn.office.net/production-osx/#{version}/MicrosoftTeams.pkg"
+  url "https://statics.teams.cdn.office.net/production-osx/#{version}/MicrosoftTeams.pkg",
+      verified: "statics.teams.cdn.office.net/"
   name "Microsoft Teams"
+  desc "Meet, chat, call, and collaborate in just one place"
   homepage "https://www.microsoft.com/en-us/microsoft-teams/group-chat-software"
 
   livecheck do

--- a/Casks/m-mpv.rb
+++ b/Casks/m-mpv.rb
@@ -8,6 +8,11 @@ cask "m-mpv" do
   desc "Media player based on MPlayer and mplayer2"
   homepage "https://mpv.io/"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   depends_on formula: "mpv"
 
   app "mpv.app"

--- a/Casks/m-mpv.rb
+++ b/Casks/m-mpv.rb
@@ -2,8 +2,10 @@ cask "m-mpv" do
   version "2023.2"
   sha256 :no_check
 
-  url "https://github.com/vitorgalvao/mpv-dummy/releases/download/#{version}/mpv.DUMMY.dmg"
+  url "https://github.com/vitorgalvao/mpv-dummy/releases/download/#{version}/mpv.DUMMY.dmg",
+      verified: "github.com/vitorgalvao/mpv-dummy/"
   name "mpv"
+  desc "Media player based on MPlayer and mplayer2"
   homepage "https://mpv.io/"
 
   depends_on formula: "mpv"

--- a/Casks/m-obs.rb
+++ b/Casks/m-obs.rb
@@ -10,9 +10,17 @@ cask "m-obs" do
   desc "Open-source software for live streaming and screen recording"
   homepage "https://obsproject.com/"
 
+  # This cask uses both stable and unstable releases, so we use a `strategy`
+  # block to override the `GithubReleases` strategy's pre-release filtering.
   livecheck do
     url :url
-    regex(/v?(\d+(?:[.-]\d+)+(?:(?:-beta\d+)|(?:-rc\d+))?)/i)
+    strategy :github_releases do |json|
+      json.map do |release|
+        next if release["draft"]
+
+        release["tag_name"]
+      end
+    end
   end
 
   app "OBS.app"

--- a/Casks/m-obs.rb
+++ b/Casks/m-obs.rb
@@ -4,8 +4,10 @@ cask "m-obs" do
   version "30.2.0-beta3"
   sha256 :no_check
 
-  url "https://github.com/obsproject/obs-studio/releases/download/#{version}/OBS-Studio-#{version}-macOS-#{arch}.dmg"
+  url "https://github.com/obsproject/obs-studio/releases/download/#{version}/OBS-Studio-#{version}-macOS-#{arch}.dmg",
+      verified: "github.com/obsproject/obs-studio/"
   name "OBS"
+  desc "Open-source software for live streaming and screen recording"
   homepage "https://obsproject.com/"
 
   livecheck do

--- a/Casks/m-tex-live-utility.rb
+++ b/Casks/m-tex-live-utility.rb
@@ -7,5 +7,18 @@ cask "m-tex-live-utility" do
   desc "Graphical user interface for TeX Live Manager"
   homepage "https://github.com/amaxwell/tlutility"
 
+  # This cask uses both stable and unstable releases, so we use a `strategy`
+  # block to override the `GithubReleases` strategy's pre-release filtering.
+  livecheck do
+    url :url
+    strategy :github_releases do |json|
+      json.map do |release|
+        next if release["draft"]
+
+        release["tag_name"]
+      end
+    end
+  end
+
   app "TeX Live Utility.app"
 end

--- a/Casks/m-tex-live-utility.rb
+++ b/Casks/m-tex-live-utility.rb
@@ -4,6 +4,7 @@ cask "m-tex-live-utility" do
 
   url "https://github.com/amaxwell/tlutility/releases/download/#{version}/TeX.Live.Utility.app-#{version}.zip"
   name "TeX Live Utility"
+  desc "Graphical user interface for TeX Live Manager"
   homepage "https://github.com/amaxwell/tlutility"
 
   app "TeX Live Utility.app"

--- a/Casks/m-tor-browser.rb
+++ b/Casks/m-tor-browser.rb
@@ -9,8 +9,9 @@ cask "m-tor-browser" do
 
   livecheck do
     url "https://dist.torproject.org/torbrowser/"
-    strategy :page_match do |page|
-      match = page.match(/(\d+(?:.\d+)+).*(\d{4}-\d{2}-\d{2})\s(\d{2}:\d{2})/i)
+    regex(/(\d+(?:.\d+)+).*?(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2})/i)
+    strategy :page_match do |page, regex|
+      match = page.match(regex)
       next if match.blank?
 
       "#{match[2].tr("-", ".")}.#{match[3].tr(":", ".")},#{match[1]}"

--- a/Casks/m-tor-browser.rb
+++ b/Casks/m-tor-browser.rb
@@ -12,12 +12,12 @@ cask "m-tor-browser" do
       match = page.match(/(\d+(?:.\d+)+).*(\d{4}-\d{2}-\d{2})\s(\d{2}:\d{2})/i)
       next if match.blank?
 
-      "#{match[2].tr("-",".")}.#{match[3].tr(":",".")},#{match[1]}"
+      "#{match[2].tr("-", ".")}.#{match[3].tr(":", ".")},#{match[1]}"
     end
   end
 
   # Stable:
   app "Tor Browser.app"
   # Alpha:
-  #app "Tor Browser Alpha.app", target: "Tor Browser.app"
+  # app "Tor Browser Alpha.app", target: "Tor Browser.app"
 end

--- a/Casks/m-tor-browser.rb
+++ b/Casks/m-tor-browser.rb
@@ -4,6 +4,7 @@ cask "m-tor-browser" do
 
   url "https://archive.torproject.org/tor-package-archive/torbrowser/#{version.csv.second}/tor-browser-macos-#{version.csv.second}.dmg"
   name "Tor Browser"
+  desc "Web browser focusing on security"
   homepage "https://www.torproject.org/"
 
   livecheck do
@@ -15,6 +16,8 @@ cask "m-tor-browser" do
       "#{match[2].tr("-", ".")}.#{match[3].tr(":", ".")},#{match[1]}"
     end
   end
+
+  depends_on macos: ">= :sierra"
 
   # Stable:
   app "Tor Browser.app"

--- a/Casks/z-test.rb
+++ b/Casks/z-test.rb
@@ -6,7 +6,7 @@ cask "z-test" do
   name "Test"
   homepage "http://www.paperstreetsoap.company/"
 
- livecheck do
+  livecheck do
     url :url
     strategy :github_latest
   end


### PR DESCRIPTION
While reviewing the `livecheck` block for `m-libreoffice` (as requested), I ended up looking through all the `livecheck` blocks in this tap. Explanations of the changes are below.

Besides that, this also resolves `brew style` offenses and `brew audit` errors, except for the `z-test` cask (as it seems intentionally incomplete).

## m-dwsim

Updates the `livecheck` block to align the check with the `url` source (so it won't surface a new version before the dmg is available on SourceForge).


## m-libreoffice

Modifies the `livecheck` block regex as follows:

* Make the trailing `Dev` part of the filename prefix optional
* Use non-greedy matching (i.e., `.+?` instead of `.+`) where appropriate
* Match the filename from the `href` attribute, aligning with typical regexes like this

Modifies the `strategy` block as follows:

* Rename the `version` variable in the `strategy` block to `versions`, as this is an array
* Simplify and inline the `path` string


## m-mpv

Adds a `livecheck` block using the `GithubLatest` strategy, as livecheck uses the `Git` strategy for the cask `url` by default but it's a GitHub release asset (so it's better to check releases instead).


## m-obs

Updates the `livecheck` block to use `GithubReleases` with a `strategy` block that only skips draft releases (avoiding the default pre-release filtering). I also dropped the regex in favor of simply using the release tag, as that won't break if the regex fails to match due to a tag format change.


## m-tex-live-utility

Same as `m-obs`, except it's a new `livecheck` block instead of modifying an existing one.


## m-tor-browser

Updates the `livecheck` block to move the regex in the `strategy` block into a preceding`#regex` call. Besides that, I made some small tweaks to the regex (`.*` -> `.*?`, `\s` -> `\s+`).